### PR TITLE
= Fix broken HTML & CSS

### DIFF
--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -39,6 +39,9 @@
 		.navbar-brand {
 			padding-top: 5px;
 		}
+		.navbar-link:hover {
+			color: white !important;
+		}
 	</style>
 
 	<!-- Tasks panel -->
@@ -53,13 +56,16 @@
 			text-align: center;
 			margin: auto;
 		}
+		.form-tasks .btn:hover {
+			color: white !important;
+		}
 
 		#filter {
-                        width: 125px;
-                        height: 28px;
-                        border-top-right-radius: 0px;
-                        border-bottom-right-radius: 0px;
-
+          width: 125px;
+          height: 28px;
+          border-top-right-radius: 0px;
+          border-bottom-right-radius: 0px;
+    }
 		#category {
 			width: 125px;
 			height: 28px;
@@ -77,7 +83,7 @@
 
 	<!-- Tables -->
 	<style type="css/text">
-		.panel-tr
+		.panel-tr {
 			width: 95%;
 			margin-left: auto;
 			margin-right: auto;
@@ -204,67 +210,67 @@
 
 <body class="animated fadeIn" style="animation-duration: 1.5s">
 	<!-- Navigation bar :: This part will be common in all the scripts -->
-	<nav class="navbar  navbar-fixed-top" "role="navigation">
+	<nav class="navbar  navbar-fixed-top" role="navigation">
 	    <div class="container">
 	    	<a class="navbar-brand" href="#"><img src="logo-nav.png" class="logo-nav">aMule WebUI</a>
 	    	<form class="navbar-form navbar-right" role="form" name="login">
 				<div class="collapse navbar-collapse">
 					<div class="btn-group">
 						<!-- Downloads -->
-						<a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-				   				<span class="glyphicon glyphicon-transfer">
+						<a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+				   				<span class="glyphicon glyphicon-transfer"></span>
 								<div style="font-size:9px"><br>Transfer</div>
-								</span>
+
 						</a>
 				   		<!-- Shared -->
 				   		<a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-					   			<span class="glyphicon glyphicon-share">
+					   			<span class="glyphicon glyphicon-share"></span>
 								<div style="font-size:9px"><br>Shared</div>
-								</span>
+
 				   				</a>
 				   		<!-- Search -->
 				   		<a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-					   			<span class="glyphicon glyphicon-search">
+					   			<span class="glyphicon glyphicon-search"></span>
 								<div style="font-size:9px"><br>Search</div>
-								</span>
+
 					   	</a>
 				   		<!-- Servers -->
 				   		<a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-					   			<span class="glyphicon glyphicon-tasks">
+					   			<span class="glyphicon glyphicon-tasks"></span>
 								<div style="font-size:9px"><br>Server</div>
-								</span>
+
 					   	</a>
 				   		<!-- Kad -->
 				   		<a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-					   			<span class="glyphicon glyphicon-asterisk">
+					   			<span class="glyphicon glyphicon-asterisk"></span>
 								<div style="font-size:9px"><br>Kad</div>
-								</span>
+
 					   	</a>
 				   		<!-- Stats -->
 				   		<a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-					   			<span class="glyphicon glyphicon-stats">
+					   			<span class="glyphicon glyphicon-stats"></span>
 								<div style="font-size:9px"><br>Stats</div>
-								</span>
+
 					   	</a>
 				   	</div>
 				   	<div class="btn-group">
 						<!-- Configuration -->
 						<a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-					   			<span class="glyphicon glyphicon-cog">
+					   			<span class="glyphicon glyphicon-cog"></span>
 								<div style="font-size:9px"><br>Settings</div>
-								</span>
+
 					   	</a>
 				   		<!-- Log -->
 				   		<a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-					   			<span class="glyphicon glyphicon-flag">
+					   			<span class="glyphicon glyphicon-flag"></span>
 								<div style="font-size:9px"><br>Logs</div>
-								</span>
+
 					   	</a>
 				   		<!-- Exit -->
 				   		<a class="btn navbar-link" title="Exit" href="login.php">
-				   				<span class="glyphicon glyphicon-off">
+				   				<span class="glyphicon glyphicon-off"></span>
 								<div style="font-size:9px"><br>Exit</div>
-								</span>
+
 				   		</a>
 				   	</div>
 		    	</div>
@@ -280,28 +286,33 @@
   		<div class="panel-body container panel-center">
     		<div class="form-inline form-tasks">
     		<div class="btn-group">
-    			<a class="btn" href="javascript:formCommandSubmit('pause');" title="Pause"><span class="glyphicon glyphicon-pause">
-			<div style="font-size:9px"><br>Pause</div>
-			</span></a>
-    			<a class="btn" href="javascript:formCommandSubmit('resume');" title="Resume"><span class="glyphicon glyphicon-play">
-			<div style="font-size:9px"><br>Resume</div>
-			</span></a>
+    			<a class="btn" href="javascript:formCommandSubmit('pause');" title="Pause">
+						<span class="glyphicon glyphicon-pause"></span>
+						<div style="font-size:9px"><br>Pause</div>
+					</a>
+    			<a class="btn" href="javascript:formCommandSubmit('resume');" title="Resume">
+						<span class="glyphicon glyphicon-play"></span>
+							<div style="font-size:9px"><br>Resume</div>
+					</a>
     		</div>
     		<div class="btn-group">
-    			<a class="btn" href="javascript:formCommandSubmit('priodown');" title="Lower priority"><span class="glyphicon glyphicon-download">
-			<div style="font-size:9px"><br>Lower Priority</div>
-			</span></a>
-    			<a class="btn" href="javascript:formCommandSubmit('cancel');" title="Remove"><span class="glyphicon glyphicon-remove-circle">
-			<div style="font-size:9px"><br>Remove</div>
-			</span></a>
-    			<a class="btn" href="javascript:formCommandSubmit('prioup');" title="Higher priority"><span class="glyphicon glyphicon-upload">
-			<div style="font-size:9px"><br>High Priority</div>
-			</span></a>
+    			<a class="btn" href="javascript:formCommandSubmit('priodown');" title="Lower priority">
+						<span class="glyphicon glyphicon-download"></span>
+						<div style="font-size:9px"><br>Lower Priority</div>
+			</a>
+    			<a class="btn" href="javascript:formCommandSubmit('cancel');" title="Remove">
+						<span class="glyphicon glyphicon-remove-circle"></span>
+						<div style="font-size:9px"><br>Remove</div>
+			</a>
+    			<a class="btn" href="javascript:formCommandSubmit('prioup');" title="Higher priority">
+						<span class="glyphicon glyphicon-upload"></span>
+						<div style="font-size:9px"><br>High Priority</div>
+			</a>
     		</div>
     		<!-- Inserting filtering php -->
     		<div class="btn-group">
      		<?php
-    			$all_status = array("all", "Waiting", "Paused", "Downloading");	
+    			$all_status = array("all", "Waiting", "Paused", "Downloading");
  				if ( $HTTP_GET_VARS["command"] == "filter") {
  					$_SESSION["filter_status"] = $HTTP_GET_VARS["status"];
  					$_SESSION["filter_cat"] = $HTTP_GET_VARS["category"];
@@ -323,9 +334,10 @@
 				}
 				echo '</select>';
     		?>
-    		<a class="btn btn-filter" href="javascript:formCommandSubmit('filter');" title="Filter"><span class="glyphicon glyphicon-filter">
-		<div style="font-size:9px"><br>Filter</div>
-		</span></a>
+    		<a class="btn btn-filter" href="javascript:formCommandSubmit('filter');" title="Filter">
+					<span class="glyphicon glyphicon-filter"></span>
+						<div style="font-size:9px"><br>Filter</div>
+					</a>
     		<?php
     			if ($_SESSION["guest_login"] != 0) {
 				    echo '<br><br><span class="label label-warning">You logged in as guest - commands are disabled</span>';

--- a/amuleweb-main-kad.php
+++ b/amuleweb-main-kad.php
@@ -37,6 +37,9 @@
     .navbar-brand {
       padding-top: 5px;
     }
+    .navbar-link:hover {
+			color: white !important;
+		}
   </style>
 
   <!-- Tables -->
@@ -224,60 +227,51 @@
         <div class="collapse navbar-collapse">
 						<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
             </div>
           </div>
@@ -314,7 +308,7 @@
     <div class="panel-heading panel-center"><h4>KAD STATUS</h4></div>
       <?php
         function print_table($kad1, $kad2) {
-          echo '<table class="table status-table" style="width:auto; margin: 0 auto; margin-bottom: 15px; margin-top:15px;"> 
+          echo '<table class="table status-table" style="width:auto; margin: 0 auto; margin-bottom: 15px; margin-top:15px;">
           <thead>
             <tr>
               <th>Parameter</th>
@@ -344,7 +338,7 @@
             if ($status["kad_firewalled"] == 0) { return '<span class="label label-success">OK</span>'; }
             else { return '<span class="label label-warning">OK</span>'; }
           } else {
-            return '<span class="label label-danger">ERROR</span>';   
+            return '<span class="label label-danger">ERROR</span>';
           }
         }
         function print_kad2($status) {
@@ -394,7 +388,7 @@
               echo  '<option>', $c, '</option>';
             }
           ?>
-              
+
             </select>
             <input class="btn btn-default btn-group" type="submit" name="Submit" value="Download link" onClick="amuleweb-main-dload.php" style="height: 30px;">
         </div>

--- a/amuleweb-main-log.php
+++ b/amuleweb-main-log.php
@@ -36,6 +36,9 @@
 		.navbar-brand {
 			padding-top: 5px;
 		}
+		.navbar-link:hover {
+			color: white !important;
+		}
 	</style>
 
 	<!-- Tasks panel -->
@@ -180,60 +183,52 @@
 				<div class="collapse navbar-collapse">
 									<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
 				   	</div>
 		    	</div>
@@ -266,7 +261,7 @@
 	<div class="container-fluid panel-tr">
 		<div class="panel">
 		<div class="panel-heading panel-center"><h4>AMULE LOG</h4></div>
-			<?php 
+			<?php
 				$amulelog = '<pre style="height:300px;background-color:#39425f;color:#ffffff"><code>' . amule_get_log($HTTP_GET_VARS['rstlog']) . '</code></pre>';
 				echo $amulelog;
 			?>
@@ -276,7 +271,7 @@
 	<div class="container-fluid panel-tr" style="margin-bottom:60px;">
 		<div class="panel">
 		<div class="panel-heading panel-center"><h4>SERVER LOG</h4></div>
-			<?php 
+			<?php
 				$serverlog = '<pre style="height:300px;background-color:#39425f;color:#ffffff"><code>' . amule_get_serverinfo($HTTP_GET_VARS['rstsrv']) . '</code></pre>';
 				echo $serverlog;
 			?>
@@ -291,10 +286,10 @@
     			<div class="btn-group">
         			<input class="form-control btn-group" name="ed2klink" type="text" id="ed2klink" placeholder="ed2k:// - Insert link" style="border-top-right-radius: 0px; border-bottom-right-radius: 0px; height: 30px;" size="25">
         			<select class="form-control btn-group" name="selectcat" id="selectcat" style="height: 30px;">
-        
+
 			        <?php
 						$cats = amule_get_categories();
-						
+
 						if ( $HTTP_GET_VARS["Submit"] != "" ) {
 							$link = $HTTP_GET_VARS["ed2klink"];
 							$target_cat = $HTTP_GET_VARS["selectcat"];
@@ -316,7 +311,7 @@
 							echo  '<option>', $c, '</option>';
 						}
 					?>
-			        
+
         		</select>
         		<input class="btn btn-default btn-group" type="submit" name="Submit" value="Download link" onClick="amuleweb-main-dload.php" style="height: 30px;">
     		</div>

--- a/amuleweb-main-prefs.php
+++ b/amuleweb-main-prefs.php
@@ -29,6 +29,9 @@
     .navbar-brand {
       padding-top: 5px;
     }
+    .navbar-link:hover {
+			color: white !important;
+		}
   </style>
 
   <!-- Tasks panel -->
@@ -160,36 +163,36 @@
     // apply new options before proceeding
 
     if ( ($HTTP_GET_VARS["Submit"] == "Apply") && ($_SESSION["guest_login"] == 0) ) {
-      $file_opts = array("check_free_space", "extract_metadata", 
+      $file_opts = array("check_free_space", "extract_metadata",
         "ich_en","aich_trust", "preview_prio","save_sources", "resume_same_cat",
         "min_free_space", "new_files_paused", "alloc_full", "alloc_full_chunks",
         "new_files_auto_dl_prio", "new_files_auto_ul_prio"
       );
       $conn_opts = array("max_line_up_cap","max_up_limit",
-        "max_line_down_cap","max_down_limit", "slot_alloc", 
+        "max_line_down_cap","max_down_limit", "slot_alloc",
         "tcp_port","udp_dis","max_file_src","max_conn_total","autoconn_en");
       $webserver_opts = array("use_gzip", "autorefresh_time");
-      
+
       $all_opts;
       foreach ($conn_opts as $i) {
         $curr_value = $HTTP_GET_VARS[$i];
         if ( $curr_value == "on") $curr_value = 1;
         if ( $curr_value == "") $curr_value = 0;
-        
+
         $all_opts["connection"][$i] = $curr_value;
       }
       foreach ($file_opts as $i) {
         $curr_value = $HTTP_GET_VARS[$i];
         if ( $curr_value == "on") $curr_value = 1;
         if ( $curr_value == "") $curr_value = 0;
-        
+
         $all_opts["files"][$i] = $curr_value;
       }
       foreach ($webserver_opts as $i) {
         $curr_value = $HTTP_GET_VARS[$i];
         if ( $curr_value == "on") $curr_value = 1;
         if ( $curr_value == "") $curr_value = 0;
-        
+
         $all_opts["webserver"][$i] = $curr_value;
       }
       //var_dump($all_opts);
@@ -197,9 +200,9 @@
     }
 
     $opts = amule_get_options();
-    
+
     $opt_groups = array("connection", "files", "webserver");
-    
+
     foreach ($opt_groups as $group) {
       $curr_opts = $opts[$group];
       //var_dump($curr_opts);
@@ -270,60 +273,51 @@
         <div class="collapse navbar-collapse">
 						<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
             </div>
           </div>
@@ -373,7 +367,7 @@
                         width: 100px" name="autorefresh_time">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -388,10 +382,10 @@
                         width: 100px" disabled="true" name="nothing">
           </div></p>
 
-          <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" " class="form-control">BANDWIDTH LIMITS</b>
+          <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" class="form-control">BANDWIDTH LIMITS</b>
 
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
 			 background-color:#ffffff;
                         color:319a9b;
@@ -406,7 +400,7 @@
                         width: 100px" name="max_down_limit">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -421,7 +415,7 @@
                         width: 100px" name="max_up_limit">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -439,7 +433,7 @@
           <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" class="form-control">CONNECTION SETTINGS</b>
 
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -454,7 +448,7 @@
                         width: 100px" name="max_conn_total">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -469,7 +463,7 @@
                         width: 100px" name="max_file_src">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -484,7 +478,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -502,7 +496,7 @@
           <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" class="form-control">CONNECTION SETTINGS</b>
 
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -517,7 +511,7 @@
                         width: 100px" name="tcp_port">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -532,7 +526,7 @@
                         width: 100px" name="udp_port">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -550,7 +544,7 @@
         <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" class="form-control">LINE CAPACITY (STATISTICS)</b>
 
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -565,7 +559,7 @@
                         width: 100px" name="max_line_down_cap">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -583,7 +577,7 @@
           <p><b style="font-size:16px; width:550px;background-color:#319a9b;color:cfd8dc" class="form-control">FILE SETTINGS</b>
 
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -599,7 +593,7 @@
                         width: 100px" name="min_free_space">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -614,7 +608,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -629,7 +623,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -644,7 +638,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -659,7 +653,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -674,7 +668,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -689,7 +683,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -704,7 +698,7 @@
                         width: 100px" disabled="true" name="nothing">
           </div>
           <div class="btn-group form-inline">
-            <label class="form-control btn-group" 
+            <label class="form-control btn-group"
               style=" width:450px;
                        background-color:#ffffff;
                         color:319a9b;
@@ -721,8 +715,8 @@
 
         </div>
 
-        
-      </div>  
+
+      </div>
     </div>
     </form>
 
@@ -734,10 +728,10 @@
           <div class="btn-group">
               <input class="form-control btn-group" name="ed2klink" type="text" id="ed2klink" placeholder="ed2k:// - Insert link" style="border-top-right-radius: 0px; border-bottom-right-radius: 0px; height: 30px;" size="25">
               <select class="form-control btn-group" name="selectcat" id="selectcat" style="height: 30px;">
-        
+
               <?php
             $cats = amule_get_categories();
-            
+
             if ( $HTTP_GET_VARS["Submit"] != "" ) {
               $link = $HTTP_GET_VARS["ed2klink"];
               $target_cat = $HTTP_GET_VARS["selectcat"];
@@ -759,7 +753,7 @@
               echo  '<option>', $c, '</option>';
             }
           ?>
-              
+
             </select>
             <input class="btn btn-default btn-group" type="submit" name="Submit" value="Download link" onClick="amuleweb-main-dload.php" style="height: 30px;">
         </div>
@@ -807,4 +801,3 @@
 
 </body>
 </html>
-

--- a/amuleweb-main-search.php
+++ b/amuleweb-main-search.php
@@ -38,6 +38,9 @@
 		.navbar-brand {
 			padding-top: 5px;
 		}
+		.navbar-link:hover {
+			color: white !important;
+		}
 	</style>
 
 	<!-- Tasks panel -->
@@ -206,20 +209,20 @@
 
 <body class="animated fadeIn" style="animation-duration: 1.5s">
 
-        <script "type="text/JavaScript">
+        <script type="text/JavaScript">
 
-$(document).ready(function(){ 
-    $(window).scroll(function(){ 
-        if ($(this).scrollTop() > 100) { 
-            $('#scroll').fadeIn(); 
-        } else { 
-            $('#scroll').fadeOut(); 
-        } 
-    }); 
-    $('#scroll').click(function(){ 
-        $("html, body").animate({ scrollTop: 0 }, 600); 
-        return false; 
-    }); 
+$(document).ready(function(){
+    $(window).scroll(function(){
+        if ($(this).scrollTop() > 100) {
+            $('#scroll').fadeIn();
+        } else {
+            $('#scroll').fadeOut();
+        }
+    });
+    $('#scroll').click(function(){
+        $("html, body").animate({ scrollTop: 0 }, 600);
+        return false;
+    });
 });
 
 
@@ -232,60 +235,59 @@ $(document).ready(function(){
 				<div class="collapse navbar-collapse">
 									<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
+
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
+
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
+
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
+
                                                 </a>
 				   	</div>
 		    	</div>
@@ -305,7 +307,7 @@ $(document).ready(function(){
     			<a class="btn btn-info btn-group" href="amuleweb-main-search.php?search_sort=<?php echo($HTTP_GET_VARS["sort"]);?>" title="Refresh to see the results" style="height:34px;">
     				<span class="glyphicon glyphicon-refresh" style="color:white"></span>
     			</a>
-    			<input type="text" placeholder="Inserire parola da cercare..." name="searchval" class="form-control btn-group" style="border-radius:0px; z-index:1;" size="70">
+    			<input type="text" placeholder="Text query..." name="searchval" class="form-control btn-group" style="border-radius:0px; z-index:1;" size="70">
     			<select class="form-control btn-group" style="border-radius:0px; background-color:#eee;" name="searchtype">
     				<option>Local</option>
     				<option selected>Global</option>
@@ -410,7 +412,7 @@ $(document).ready(function(){
 						$result = 1;
 						switch($str) {
 							case "Byte":	$result = 1; break;
-							case "KByte":	$result = 1024; break;		
+							case "KByte":	$result = 1024; break;
 							case "MByte":	$result = 1012*1024; break;
 							case "GByte":	$result = 1012*1024*1024; break;
 						}
@@ -439,7 +441,7 @@ $(document).ready(function(){
 
 							$min_size *= str2mult($HTTP_GET_VARS["minsizeu"]);
 							$max_size *= str2mult($HTTP_GET_VARS["maxsizeu"]);
-							
+
 							amule_do_search_start_cmd($HTTP_GET_VARS["searchval"],
 								//$HTTP_GET_VARS["ext"], $HTTP_GET_VARS["filetype"],
 								"", "",
@@ -455,7 +457,7 @@ $(document).ready(function(){
 							}
 						} else {
 						}
-					}		
+					}
 					$search = amule_load_vars("searchresult");
 
 					$sort_order = $HTTP_GET_VARS["sort"];
@@ -484,7 +486,7 @@ $(document).ready(function(){
 						echo '</tr>';
 					}
 
-					
+
 				?>
 				</tbody>
 			</table>
@@ -499,10 +501,10 @@ $(document).ready(function(){
     			<div class="btn-group">
         			<input class="form-control btn-group" name="ed2klink" type="text" id="ed2klink" placeholder="ed2k:// - Insert link" style="border-top-right-radius: 0px; border-bottom-right-radius: 0px; height: 30px;" size="25">
         			<select class="form-control btn-group" name="selectcat" id="selectcat" style="height: 30px;">
-        
+
 			        <?php
 						$cats = amule_get_categories();
-						
+
 						if ( $HTTP_GET_VARS["Submit"] != "" ) {
 							$link = $HTTP_GET_VARS["ed2klink"];
 							$target_cat = $HTTP_GET_VARS["selectcat"];
@@ -524,7 +526,7 @@ $(document).ready(function(){
 							echo  '<option>', $c, '</option>';
 						}
 					?>
-			        
+
         		</select>
         		<input class="btn btn-default btn-group" type="submit" name="Submit" value="Download link" onClick="amuleweb-main-dload.php" style="height: 30px;">
     		</div>

--- a/amuleweb-main-servers.php
+++ b/amuleweb-main-servers.php
@@ -29,6 +29,9 @@
 		.navbar-brand {
 			padding-top: 5px;
 		}
+		.navbar-link:hover {
+			color: white !important;
+		}
 	</style>
 
 	<!-- Tables -->
@@ -111,7 +114,7 @@
                   }
                   a:hover {
                         color:#fff;
-                        } 
+                        }
 		                a {
                         color:#4db6ac;
                 }
@@ -136,60 +139,51 @@
 				<div class="collapse navbar-collapse">
 									<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
 				   	</div>
 		    	</div>

--- a/amuleweb-main-shared.php
+++ b/amuleweb-main-shared.php
@@ -29,6 +29,9 @@
 		.navbar-brand {
 			padding-top: 5px;
 		}
+		.navbar-link:hover {
+			color: white !important;
+		}
 	</style>
 
 	<!-- Tasks panel -->
@@ -41,6 +44,9 @@
 		.panel-center {
 			text-align: center;
 			margin: auto;
+		}
+		.form-tasks .btn:hover {
+			color: white !important;
 		}
 		#filter {
 			width: 125px;
@@ -185,60 +191,51 @@ function formCommandSubmit(command)
 				<div class="collapse navbar-collapse">
 									<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
 				   	</div>
 		    	</div>
@@ -254,15 +251,18 @@ function formCommandSubmit(command)
     		<div class="form-inline form-tasks" action="amuleweb-main-shared.php" method="post" name="mainform">
     		<input type="hidden" name="command">
     		<div class="btn-group">
-    			<a class="btn" href="javascript:formCommandSubmit('priodown');" title="Lower priority"><span class="glyphicon glyphicon-download">
-			<div style="font-size:9px"><br>Lower Priority</div>
-			</span></a>
-    			<a class="btn" href="javascript:formCommandSubmit('reload');" title="Refresh"><span class="glyphicon glyphicon-refresh">
-			<div style="font-size:9px"><br>Refresh</div>
-			</span></a>
-    			<a class="btn" href="javascript:formCommandSubmit('prioup');" title="Higher priority"><span class="glyphicon glyphicon-upload">
-			<div style="font-size:9px"><br>High Priority</div>
-			</span></a>
+    			<a class="btn" href="javascript:formCommandSubmit('priodown');" title="Lower priority">
+						<span class="glyphicon glyphicon-download"></span>
+						<div style="font-size:9px"><br>Lower Priority</div>
+					</a>
+    			<a class="btn" href="javascript:formCommandSubmit('reload');" title="Refresh">
+						<span class="glyphicon glyphicon-refresh"></span>
+						<div style="font-size:9px"><br>Refresh</div>
+					</a>
+    			<a class="btn" href="javascript:formCommandSubmit('prioup');" title="Higher priority">
+						<span class="glyphicon glyphicon-upload"></span>
+						<div style="font-size:9px"><br>High Priority</div>
+					</a>
     		</div>
     		<!-- Inserting filtering php -->
     		<div class="btn-group">
@@ -273,9 +273,10 @@ function formCommandSubmit(command)
      				<option>High</option>
      				<option>Release</option>
      			</select>
-    			<a class="btn btn-filter" href="javascript:formCommandSubmit('setprio');" title="Filter"><span class="glyphicon glyphicon-check">
-			<div style="font-size:9px"><br>Filter</div>
-			</span></a>
+    			<a class="btn btn-filter" href="javascript:formCommandSubmit('setprio');" title="Filter">
+						<span class="glyphicon glyphicon-check"></span>
+						<div style="font-size:9px"><br>Filter</div>
+					</a>
     			<?php
     				if ($_SESSION["guest_login"] != 0) {
 					    echo '<br><br><span class="label label-warning">You logged in as guest - commands are disabled</span>';

--- a/amuleweb-main-stats.php
+++ b/amuleweb-main-stats.php
@@ -60,6 +60,9 @@
     .navbar-brand {
       padding-top: 5px;
     }
+    .navbar-link:hover {
+			color: white !important;
+		}
     .btn-dark {
       background-color: hsl(0, 0%, 16%) !important;
       background-repeat: repeat-x;
@@ -80,7 +83,7 @@
 
   <!-- Tables -->
   <style type="css/text">
-    .panel-tr {   
+    .panel-tr {
       width: 95%;
       margin-left: auto;
       margin-right: auto;
@@ -189,60 +192,51 @@
         <div class="collapse navbar-collapse">
 						<div class="btn-group">
                                                 <!-- Downloads -->
-                                                <a class="btn  navbar-link title="Downloads and Uploads" href="amuleweb-main-dload.php">
-                                                                <span class="glyphicon glyphicon-transfer">
+                                                <a class="btn  navbar-link" title="Downloads and Uploads" href="amuleweb-main-dload.php">
+                                                                <span class="glyphicon glyphicon-transfer"></span>
                                                                 <div style="font-size:9px"><br>Transfer</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Shared -->
                                                 <a class="btn  navbar-link" title="Sharing" href="amuleweb-main-shared.php">
-                                                                <span class="glyphicon glyphicon-share">
+                                                                <span class="glyphicon glyphicon-share"></span>
                                                                 <div style="font-size:9px"><br>Shared</div>
-                                                                </span>
                                                                 </a>
                                                 <!-- Search -->
                                                 <a class="btn  navbar-link" title="Search" href="amuleweb-main-search.php">
-                                                                <span class="glyphicon glyphicon-search">
+                                                                <span class="glyphicon glyphicon-search"></span>
                                                                 <div style="font-size:9px"><br>Search</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Servers -->
                                                 <a class="btn  navbar-link" title="Servers" href="amuleweb-main-servers.php">
-                                                                <span class="glyphicon glyphicon-tasks">
+                                                                <span class="glyphicon glyphicon-tasks"></span>
                                                                 <div style="font-size:9px"><br>Server</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Kad -->
                                                 <a class="btn  navbar-link" title="Kademlia" href="amuleweb-main-kad.php">
-                                                                <span class="glyphicon glyphicon-asterisk">
+                                                                <span class="glyphicon glyphicon-asterisk"></span>
                                                                 <div style="font-size:9px"><br>Kad</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Stats -->
                                                 <a class="btn  navbar-link" title="Statistics" href="amuleweb-main-stats.php">
-                                                                <span class="glyphicon glyphicon-stats">
+                                                                <span class="glyphicon glyphicon-stats"></span>
                                                                 <div style="font-size:9px"><br>Stats</div>
-                                                                </span>
                                                 </a>
                                         </div>
                                         <div class="btn-group">
                                                 <!-- Configuration -->
                                                 <a class="btn navbar-link" title="Configurations" href="amuleweb-main-prefs.php">
-                                                                <span class="glyphicon glyphicon-cog">
+                                                                <span class="glyphicon glyphicon-cog"></span>
                                                                 <div style="font-size:9px"><br>Settings</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Log -->
                                                 <a class="btn  navbar-link" title="Log" href="amuleweb-main-log.php">
-                                                                <span class="glyphicon glyphicon-flag">
+                                                                <span class="glyphicon glyphicon-flag"></span>
                                                                 <div style="font-size:9px"><br>Logs</div>
-                                                                </span>
                                                 </a>
                                                 <!-- Exit -->
                                                 <a class="btn navbar-link" title="Exit" href="login.php">
-                                                                <span class="glyphicon glyphicon-off">
+                                                                <span class="glyphicon glyphicon-off"></span>
                                                                 <div style="font-size:9px"><br>Exit</div>
-                                                                </span>
                                                 </a>
             </div>
           </div>
@@ -306,7 +300,7 @@
         </div>
       </div>
       </div>
-      </div> 
+      </div>
     </div>
 
 
@@ -318,10 +312,10 @@
           <div class="btn-group">
               <input class="form-control btn-group" name="ed2klink" type="text" id="ed2klink" placeholder="ed2k:// - Insert link" style="border-top-right-radius: 0px; border-bottom-right-radius: 0px; height: 30px;" size="25">
               <select class="form-control btn-group" name="selectcat" id="selectcat" style="height: 30px;">
-        
+
               <?php
             $cats = amule_get_categories();
-            
+
             if ( $HTTP_GET_VARS["Submit"] != "" ) {
               $link = $HTTP_GET_VARS["ed2klink"];
               $target_cat = $HTTP_GET_VARS["selectcat"];
@@ -343,7 +337,7 @@
               echo  '<option>', $c, '</option>';
             }
           ?>
-              
+
             </select>
             <input class="btn btn-default btn-group" type="submit" name="Submit" value="Download link" onClick="amuleweb-main-dload.php" style="height: 30px;">
         </div>


### PR DESCRIPTION
Uf.....
The way this template got setup makes it impossible to maintain. I understand that because of aMule's PHP, we can't do things like including/requiring in php to avoid duplicated content but what about styles??
Why weren't they placed on a `styles.css` rather than duplicating them everywhere?

Anyway, i fixed multiple broken styles and html.
Like:
![1](https://user-images.githubusercontent.com/1708730/108888989-1d686c80-760c-11eb-8c30-46e32851de59.png)

Which now looks:
![2](https://user-images.githubusercontent.com/1708730/108889016-26f1d480-760c-11eb-8abc-b507adbf7b8e.png)


Closes https://github.com/MatteoRagni/AmuleWebUI-Reloaded/issues/22 , https://github.com/MatteoRagni/AmuleWebUI-Reloaded/issues/21