### PR TITLE
Hide totalizers and add label

### DIFF
--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -582,17 +582,19 @@
 							
 						}
 					}
-					print "<tr>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSize, $fakevar), "</td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
-						((float)$countCompleted*100)/((float)$countSize), "%)</td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", ($countSpeed > 0) ? (CastToXBytes($countSpeed, $fakevar) . "/s" ) : "", "</td>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "</tr>";
+					if (count($downloads)>0) {
+						print "<tr>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;'>Total</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSize, $fakevar), "</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
+							((float)$countCompleted*100)/((float)$countSize), "%)</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", ($countSpeed > 0) ? (CastToXBytes($countSpeed, $fakevar) . "/s" ) : "", "</td>";
+						echo "<td style='padding-bottom:0;'></td>";
+						echo "<td style='padding-bottom:0;'></td>";
+						echo "<td style='padding-bottom:0;'></td>";
+						echo "<td style='padding-bottom:0;'></td>";
+						echo "</tr>";
+					}
 					?>
 				</tbody>
 			</table>
@@ -646,12 +648,14 @@
 						// Speed
 						echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", ($file->xfer_speed > 0) ? (CastToXBytes($file->xfer_speed, $countSpeed) . "/s") : "", "</td>";
 					}
-					echo "<tr>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='padding-bottom:0;'></td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countUploadDimension, $fakevar), "</td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countDownloadDimension, $fakevar), "</td>";
-					echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSpeed, $fakevar) . "/s", "</td>";
+					if (count($uploads)>0) {
+						echo "<tr>";
+						echo "<td style='padding-bottom:0;'></td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;'>Total</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countUploadDimension, $fakevar), "</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countDownloadDimension, $fakevar), "</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSpeed, $fakevar) . "/s", "</td>";
+					}
 				?>
       </table>
 

--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -584,7 +584,7 @@
 					}
 					if (count($downloads)>0) {
 						print "<tr>";
-						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;'>Total</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;padding-right: 20px;'>Total</td>";
 						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSize, $fakevar), "</td>";
 						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countCompleted, $fakevar), "&nbsp;(",
 							((float)$countCompleted*100)/((float)$countSize), "%)</td>";
@@ -651,7 +651,7 @@
 					if (count($uploads)>0) {
 						echo "<tr>";
 						echo "<td style='padding-bottom:0;'></td>";
-						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;'>Total</td>";
+						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;text-align: right;padding-right: 20px;'>Total</td>";
 						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countUploadDimension, $fakevar), "</td>";
 						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countDownloadDimension, $fakevar), "</td>";
 						echo "<td style='font-size:12px;color:#c9c9c9;padding-bottom:0;'>", CastToXBytes($countSpeed, $fakevar) . "/s", "</td>";


### PR DESCRIPTION
Fix issue #32 
Hide totalizers, when the list is empty:
![image](https://user-images.githubusercontent.com/9451876/191087046-645f7a57-7003-4630-b420-448d6935a7c4.png)

Add label "Total":
![image](https://user-images.githubusercontent.com/9451876/191089032-0336316f-0241-45ee-9a70-3d99cc348198.png)

