### PR TITLE
Add tooltip to show complete file name #25

### DIFF
--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -23,6 +23,12 @@
 	<script type="text/Javascript">
 		$(function () { $("[data-toggle='tooltip']").tooltip(); });
 		$(function () { $("[data-toggle='popover']").popover(); });
+		$(function () { $("[data-toggle='popoverTooltip']").popover({ container: 'body',
+			html: true,
+			content: function () {
+				return $(this).next('.popper-content').html();
+			}
+		}); });
 	</script>
 
 
@@ -129,6 +135,13 @@
                 	background-color:#319a9b;
                 	color:black;
 			border: 1;
+                }
+				.popover-content {
+					background-color:#319a9b;
+					color:#cfd8dc;
+					border: 1;
+					word-wrap: break-word;
+					font-weight: bold;
                 }
 		.glyphicon + span {
     			position: absolute;
@@ -497,10 +510,12 @@
 					}
 					function create_tooltip($name) {
 						echo '	<div class="texte" style="margin: 0px;"
-									data-toggle="popover" data-placement="bottom"
-									data-html="true" data-trigger="hover" data-content='. "'<b>" . $name . "</b>'" . '>
+									data-toggle="popoverTooltip" data-placement="bottom"
+									data-html="true" data-trigger="hover" >
 									<b>&nbsp;'. $name .'</b>
-								</div>';
+								
+								</div>
+								<div class="popper-content hide">&nbsp;'. $name .'</div>';
 					}
 					// perform command before processing content
 					if ( ($HTTP_GET_VARS["command"] != "") && ($_SESSION["guest_login"] == 0) ) {
@@ -635,12 +650,22 @@
 						}
 						return $result;
 					}
+					function utf8_rawurldecode($raw_url_encoded){
+						$enc = rawurldecode($raw_url_encoded);
+						if(utf8_encode(utf8_decode($enc))==$enc){;
+							return rawurldecode($raw_url_encoded);
+						}else{
+							return utf8_encode(rawurldecode($raw_url_encoded));
+						}
+					}
 					function create_tooltip($name) {
 						echo '	<div class="texte" style="margin: 0px;"
-									data-toggle="popover" data-placement="bottom"
-									data-html="true" data-trigger="hover" data-content='. "'<b>" . $name . "</b>'" . '>
+									data-toggle="popoverTooltip" data-placement="bottom"
+									data-html="true" data-trigger="hover" >
 									<b>&nbsp;'. $name .'</b>
-								</div>';
+								
+								</div>
+								<div class="popper-content hide">&nbsp;'. $name .'</div>';
 					}
 					$countUploadDimension = 0;
 					$countDownloadDimension = 0;
@@ -651,7 +676,7 @@
 					foreach ($uploads as $file) {
 						echo "<tr>";
 						// Name
-						echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'><b>", create_tooltip($file->name), "</b></td>";
+						echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'><b>", create_tooltip($file->name) , "</b></td>";
 						// User name
 						echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", $file->user_name, "</td>";
 						// Upload dimension

--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -495,7 +495,13 @@
 								    <div '.$status.' role="progressbar" aria-valuenow="'.$done.'" aria-valuemin="0" aria-valuemax="100" style="width: '.$done.'%"></div>
 								</div>';
 					}
-
+					function create_tooltip($name) {
+						echo '	<div class="texte" style="margin: 0px;"
+									data-toggle="popover" data-placement="bottom"
+									data-html="true" data-trigger="hover" data-content='. "'<b>" . $name . "</b>'" . '>
+									<b>&nbsp;'. $name .'</b>
+								</div>';
+					}
 					// perform command before processing content
 					if ( ($HTTP_GET_VARS["command"] != "") && ($_SESSION["guest_login"] == 0) ) {
 						foreach ( $HTTP_GET_VARS as $name => $val) {
@@ -554,7 +560,7 @@
 						if ( $filter_status_result and $filter_cat_result) {
 							print "<tr>";
 								// Name and checkbox
-								echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'>", '<div class="checkbox download-checkbox" style="margin: 0px;"><label><input type="checkbox" name="', $file->hash, '" >&nbsp;<b>', $file->name, "</b></label></div></td>";
+								echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'>", '<div class="checkbox download-checkbox" style="margin: 0px;"><label><input type="checkbox" name="', $file->hash, '" >', create_tooltip($file->name) , "</label></div></td>";
 								echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", CastToXBytes($file->size, $countSize), "</td>";
 								// Size
 								echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", CastToXBytes($file->size_done, $countCompleted), "&nbsp;(",
@@ -629,6 +635,13 @@
 						}
 						return $result;
 					}
+					function create_tooltip($name) {
+						echo '	<div class="texte" style="margin: 0px;"
+									data-toggle="popover" data-placement="bottom"
+									data-html="true" data-trigger="hover" data-content='. "'<b>" . $name . "</b>'" . '>
+									<b>&nbsp;'. $name .'</b>
+								</div>';
+					}
 					$countUploadDimension = 0;
 					$countDownloadDimension = 0;
 					$countSpeed = 0;
@@ -638,7 +651,7 @@
 					foreach ($uploads as $file) {
 						echo "<tr>";
 						// Name
-						echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'><b>", $file->name, "</b></td>";
+						echo "<td style='font-size:12px;color:#f5f5f5' class='texte texte-full-name'><b>", create_tooltip($file->name), "</b></td>";
 						// User name
 						echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", $file->user_name, "</td>";
 						// Upload dimension


### PR DESCRIPTION
Issue #25, use the tooltip component to show file full name, is being used in the progress bar:
## Desktop:
![image](https://user-images.githubusercontent.com/9451876/191818283-fa5e9e3d-820e-4906-bb48-dbbd087262f9.png)
## Mobile :
![image](https://user-images.githubusercontent.com/9451876/191818475-bb7e6028-2045-4b58-8d31-10d155886707.png)
### Android chrome
![image](https://user-images.githubusercontent.com/9451876/191818520-353ef87f-cb24-413b-a2d2-8e6435a9237a.png)
### Android firefox
![image](https://user-images.githubusercontent.com/9451876/191818808-8345f3c3-9019-46ad-b282-6ce2dd61bf8c.png)
@ngosang
