### PR TITLE
Added missing options in amuleweb-main-prefs.php options apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Update style of 'AmuleWebUI-Reloaded' in Material design with CSS
 * ThecaTTony for fixing an error in sort by files ([Pull 9](https://github.com/MatteoRagni/AmuleWebUI-Reloaded/pull/9))
 * Daneden for animate .css `https://github.com/daneden/animate.css/`
 * tetreum fixed a bug in css ([Pull 23](https://github.com/MatteoRagni/AmuleWebUI-Reloaded/pull/23)) and in refreshing pages ([Pull 24](https://github.com/MatteoRagni/AmuleWebUI-Reloaded/pull/24))
+* RealGreenDragon for fixing a bug in web option settings ([Pull 44](https://github.com/MatteoRagni/AmuleWebUI-Reloaded/pull/44))
 
 ## Structure 
 

--- a/amuleweb-main-prefs.php
+++ b/amuleweb-main-prefs.php
@@ -170,7 +170,7 @@
       );
       $conn_opts = array("max_line_up_cap","max_up_limit",
         "max_line_down_cap","max_down_limit", "slot_alloc",
-        "tcp_port","udp_dis","max_file_src","max_conn_total","autoconn_en");
+        "tcp_port","udp_port","udp_dis","max_file_src","max_conn_total","autoconn_en","reconn_en");
       $webserver_opts = array("use_gzip", "autorefresh_time");
 
       $all_opts;


### PR DESCRIPTION
Options "udp_port" and "reconn_en" are present in JS code that populate options page with values from backend, but not in PHP code that save POST provided values into backend.
This is also a bug in aMule default webserver skin, where I opened an identical PR: https://github.com/amule-project/amule/pull/414