### PR TITLE
Skip ed2k empty links

### DIFF
--- a/amuleweb-main-dload.php
+++ b/amuleweb-main-dload.php
@@ -260,7 +260,7 @@
 			{
 				checkboxes.forEach(function(checkbox) {
 					checkbox.checked = true;
-				});			
+				});
 			}
 			else
 			{
@@ -544,7 +544,7 @@
 									data-toggle="popoverTooltip" data-placement="bottom"
 									data-html="true" data-trigger="hover" >
 									<b>&nbsp;'. $name .'</b>
-								
+
 								</div>
 								<div class="popper-content hide">&nbsp;'. $name .'</div>';
 					}
@@ -633,7 +633,7 @@
 								// Priority
 								echo "<td style='font-size:12px;color:#f5f5f5' class='texte'>", PrioString($file), "</td>";
 							echo "</tr>";
-							
+
 						}
 					}
 					if (count($downloads) > 0 and $countSize > 0) {
@@ -696,7 +696,7 @@
 									data-toggle="popoverTooltip" data-placement="bottom"
 									data-html="true" data-trigger="hover" >
 									<b>&nbsp;'. $name .'</b>
-								
+
 								</div>
 								<div class="popper-content hide">&nbsp;'. $name .'</div>';
 					}
@@ -760,7 +760,9 @@
 							if ( strlen($link) > 0 ) {
 								$links = split("ed2k://", $link);
 								foreach($links as $linkn) {
-								    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									if (strlen($linkn) > 0){
+										amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									}
 								}
 							}
 						}

--- a/amuleweb-main-kad.php
+++ b/amuleweb-main-kad.php
@@ -379,7 +379,9 @@
               if ( strlen($link) > 0 ) {
                 $links = split("ed2k://", $link);
                 foreach($links as $linkn) {
+                  if (strlen($linkn) > 0){
                     amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+                  }
                 }
               }
             }

--- a/amuleweb-main-log.php
+++ b/amuleweb-main-log.php
@@ -302,7 +302,9 @@
 							if ( strlen($link) > 0 ) {
 								$links = split("ed2k://", $link);
 								foreach($links as $linkn) {
-								    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									if (strlen($linkn) > 0){
+										amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									}
 								}
 							}
 						}

--- a/amuleweb-main-prefs.php
+++ b/amuleweb-main-prefs.php
@@ -744,7 +744,9 @@
               if ( strlen($link) > 0 ) {
                 $links = split("ed2k://", $link);
                 foreach($links as $linkn) {
+                  if (strlen($linkn) > 0){
                     amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+                  }
                 }
               }
             }

--- a/amuleweb-main-search.php
+++ b/amuleweb-main-search.php
@@ -227,7 +227,7 @@
 			{
 				checkboxes.forEach(function(checkbox) {
 					checkbox.checked = true;
-				});			
+				});
 			}
 			else
 			{
@@ -553,7 +553,9 @@ $(document).ready(function(){
 							if ( strlen($link) > 0 ) {
 								$links = split("ed2k://", $link);
 								foreach($links as $linkn) {
-								    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									if (strlen($linkn) > 0){
+										amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									}
 								}
 							}
 						}

--- a/amuleweb-main-servers.php
+++ b/amuleweb-main-servers.php
@@ -308,7 +308,9 @@
 							if ( strlen($link) > 0 ) {
 								$links = split("ed2k://", $link);
 								foreach($links as $linkn) {
-								    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									if (strlen($linkn) > 0){
+										amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+									}
 								}
 							}
 						}

--- a/amuleweb-main-shared.php
+++ b/amuleweb-main-shared.php
@@ -185,7 +185,7 @@ function selectAll(check)
 		{
 			checkboxes.forEach(function(checkbox) {
 				checkbox.checked = true;
-			});			
+			});
 		}
 		else
 		{
@@ -495,7 +495,9 @@ function selectAll(check)
 								if ( strlen($link) > 0 ) {
 									$links = split("ed2k://", $link);
 									foreach($links as $linkn) {
-									    amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+										if (strlen($linkn) > 0){
+											amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+										}
 									}
 								}
 							}

--- a/amuleweb-main-stats.php
+++ b/amuleweb-main-stats.php
@@ -328,7 +328,9 @@
               if ( strlen($link) > 0 ) {
                 $links = split("ed2k://", $link);
                 foreach($links as $linkn) {
+                  if (strlen($linkn) > 0){
                     amule_do_ed2k_download_cmd("ed2k://" . $linkn, $target_cat_idx);
+                  }
                 }
               }
             }


### PR DESCRIPTION
Fixed little bug on "ed2k:// - Insert link" forms (in all pages).

Currently if any link is added seems amuleweb adds another empty link before the correct link:
```
!2025-12-30 18:08:00: ExternalConn: adding link 'ed2k://'.
!2025-12-30 18:08:00: Invalid eD2k link! ERROR: Not a valid ed2k-URI
!2025-12-30 18:08:00: ExternalConn: adding link 'ed2k://|file|<FILE_DATA>/ '.
!2025-12-30 18:08:00: <SUCCESS_MSG>
```
The cause is the split before amule_do_ed2k_download_cmd call that generate an empty string.
With this fix empty links are filtered and no more strange errors happens:
```
!2025-12-30 18:10:00: ExternalConn: adding link 'ed2k://|file|<FILE_DATA>/ '.
!2025-12-30 18:10:00: <SUCCESS_MSG>
```
In meanwhile I removed some extra spaces present in some php files.